### PR TITLE
Fixing an issue with 'AADSyncRules.AttributeFlowMappings.Expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The property 'Expression' in 'AADSyncRules.AttributeFlowMappings' cannot be $null.
+
 ## [0.1.0] - 2024-07-04
 
 ### Changed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ stages:
           vmImage: 'windows-latest'
         steps:
           - pwsh: |
-              dotnet tool install --global GitVersion.Tool
+              dotnet tool install --global GitVersion.Tool --version 5.*
               $gitVersionObject = dotnet-gitversion | ConvertFrom-Json
               $gitVersionObject.PSObject.Properties.ForEach{
                   Write-Host -Object "Setting Task Variable '$($_.Name)' with value '$($_.Value)'."

--- a/source/DSCResources/AADSyncRules/AADSyncRules.schema.psm1
+++ b/source/DSCResources/AADSyncRules/AADSyncRules.schema.psm1
@@ -15,6 +15,15 @@ configuration AADSyncRules {
             $item.Ensure = 'Present'
         }
 
+        #Expression is a key property, it cannot be $null
+        foreach ($afm in $item.AttributeFlowMappings)
+        {
+            if ($null -eq $afm.Expression)
+            {
+                $afm.Expression = ''
+            }
+        }
+
         $executionName = ($item.ConnectorName + '__' + $item.Name) -replace '[\s(){}/\\:-]', '_'
         (Get-DscSplattedResource -ResourceName AADSyncRule -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
     }


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

### Fixed
- The property 'Expression' in 'AADSyncRules.AttributeFlowMappings' cannot be $null.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
